### PR TITLE
Feat/version update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "cin-validator"
-version = "0.1.0"
+version = "0.1.3"
 description = "Shared module for validating CIN census data using DfE rules."
-authors = ["DatatoInsight's children's social care analyst community", "Tambe Tabitha <tambe.tabitha@socialfinance.org.uk>", "Kaj Siebert <kaj.siebert@socialfinance.org.uk>", "William Levack-Payne <william.levack-payne@eastsussex.gov.uk>", ]
+authors = "Tambe Tabitha <tambe.tabitha@socialfinance.org.uk>, Kaj Siebert <kaj.siebert@socialfinance.org.uk>, William Levack-Payne <william.levack-payne@eastsussex.gov.uk>, DatatoInsight's children's social care analyst community"
 packages = [
     { include = "rpc_main.py" },
     { include = "cin_validator/**/*.py"  }	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cin-validator"
 version = "0.1.3"
 description = "Shared module for validating CIN census data using DfE rules."
-authors = "Tambe Tabitha <tambe.tabitha@socialfinance.org.uk>, Kaj Siebert <kaj.siebert@socialfinance.org.uk>, William Levack-Payne <william.levack-payne@eastsussex.gov.uk>, DatatoInsight's children's social care analyst community"
+authors = ["Tambe Tabitha <tambe.tabitha@socialfinance.org.uk>, Kaj Siebert <kaj.siebert@socialfinance.org.uk>, William Levack-Payne <william.levack-payne@eastsussex.gov.uk>, DatatoInsight's children's social care analyst community <datatoinsight.enquiries@gmail.com>"]
 packages = [
     { include = "rpc_main.py" },
     { include = "cin_validator/**/*.py"  }	


### PR DESCRIPTION
- move tool version to 0.1.3 so that this can be reflected in the wheel name when `poetry build` is run. The refactoring changes and tweaks that have been done to sync with the 903 backend have been release as cin_validator `v0.1.3`. This pull request will be added to that release when it is merged.
- convert authors list to array of one string in an [attempt to enable the display of multiple authors](https://bugs.python.org/msg93286) on PyPI. 