### PR TITLE
Split Assessment Factors into separate dataframe to reduce duplication of error rows passed to FE

### DIFF
--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -91,7 +91,7 @@ def run_all(filename: str, ruleset, select, output):
 
     # click.echo(full_issue_df)
     # click.echo(validator.multichild_issues)
-    click.echo(validator.data_files["AssessmentFactors"])
+    click.echo(validator.data_files["AssessmentFactorsList"])
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -91,7 +91,7 @@ def run_all(filename: str, ruleset, select, output):
 
     # click.echo(full_issue_df)
     # click.echo(validator.multichild_issues)
-    click.echo(validator.data_files["ChildIdentifiers"])
+    click.echo(validator.data_files["AssessmentFactors"])
 
 
 @cli.command(name="test")

--- a/cin_validator/__main__.py
+++ b/cin_validator/__main__.py
@@ -91,7 +91,7 @@ def run_all(filename: str, ruleset, select, output):
 
     # click.echo(full_issue_df)
     # click.echo(validator.multichild_issues)
-    click.echo(validator.data_files["AssessmentFactorsList"])
+    click.echo(validator.data_files["Assessments"])
 
 
 @cli.command(name="test")

--- a/cin_validator/cin_validator.py
+++ b/cin_validator/cin_validator.py
@@ -52,7 +52,7 @@ def convert_data(root: ET.Element):
         "Reviews": data_files.Reviews,
         "Section47": data_files.Section47,
         "Assessments": data_files.Assessments,
-        "AssessmentFactors": data_files.AssessmentFactors,
+        "AssessmentFactorsList": data_files.AssessmentFactorsList,
         "Disabilities": data_files.Disabilities,
     }
     return cin_tables

--- a/cin_validator/cin_validator.py
+++ b/cin_validator/cin_validator.py
@@ -52,6 +52,7 @@ def convert_data(root: ET.Element):
         "Reviews": data_files.Reviews,
         "Section47": data_files.Section47,
         "Assessments": data_files.Assessments,
+        "AssessmentFactors": data_files.AssessmentFactors,
         "Disabilities": data_files.Disabilities,
     }
     return cin_tables

--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -329,6 +329,7 @@ class XMLtoCSV:
 
         self.AssessmentID = 0
         assessments = cin_detail.findall("Assessments")
+
         for assessment in assessments:
             self.AssessmentID += 1
             assessment_dict = {
@@ -336,6 +337,7 @@ class XMLtoCSV:
                 "CINdetailsID": self.CINdetailsID,
                 "AssessmentID": self.AssessmentID,
             }
+
             assessment_dict = get_values(elements, assessment_dict, assessment)
 
             # the get_values function will not find AssessmentFactors on that level so we retrieve these separately.
@@ -364,9 +366,10 @@ class XMLtoCSV:
                     [self.AssessmentFactorsList, assessment_factors_df],
                     ignore_index=True,
                 )
-            assessment_dict["AssessmentFactors"] = assessment_factors_df[
-                "AssessmentFactor"
-            ].tolist()
+                assessment_dict["AssessmentFactors"] = assessment_factors_df[
+                    "AssessmentFactor"
+                ].tolist()
+
             assessments_list.append(assessment_dict)
 
         assessments_df = pd.DataFrame(assessments_list)

--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -90,9 +90,10 @@ class XMLtoCSV:
             "AssessmentActualStartDate",
             "AssessmentInternalReviewDate",
             "AssessmentAuthorisationDate",
+            "AssessmentFactors",
         ]
     )
-    AssessmentFactors = pd.DataFrame(
+    AssessmentFactorsList = pd.DataFrame(
         columns=[
             "LAchildID",
             "CINdetailsID",
@@ -341,23 +342,28 @@ class XMLtoCSV:
             # the get_values function will not find AssessmentFactors on that level so we retrieve these separately.
             assessment_factors = assessment.find("FactorsIdentifiedAtAssessment")
             assessment_factors_list = []
-            assessment_columns = self.AssessmentFactors.columns
-            assessment_elements = list(set(assessment_columns).difference(set(self.id_cols)))
+            assessment_columns = self.AssessmentFactorsList.columns
+            assessment_elements = list(
+                set(assessment_columns).difference(set(self.id_cols))
+            )
             if assessment_factors is not None:
                 # if statement handles the non-iterable NoneType that .find produces if the element is not present.
                 for factor in assessment_factors:
                     assessment_factors_dict = {
-                    "LAchildID": self.LAchildID,
-                    "CINdetailsID": self.CINdetailsID,
-                    "AssessmentID": self.AssessmentID,
+                        "LAchildID": self.LAchildID,
+                        "CINdetailsID": self.CINdetailsID,
+                        "AssessmentID": self.AssessmentID,
                     }
-                    assessment_factors_dict = get_values(assessment_elements, assessment_factors_dict, factor)
+                    assessment_factors_dict = get_values(
+                        assessment_elements, assessment_factors_dict, factor
+                    )
                     assessment_factors_dict["AssessmentFactor"] = factor.text
                     assessment_factors_list.append(assessment_factors_dict)
                 assessment_factors_df = pd.DataFrame(assessment_factors_list)
-                self.AssessmentFactors = pd.concat(
-                    [self.AssessmentFactors, assessment_factors_df], ignore_index=True
-                    )
+                self.AssessmentFactorsList = pd.concat(
+                    [self.AssessmentFactorsList, assessment_factors_df],
+                    ignore_index=True,
+                )
 
         assessments_df = pd.DataFrame(assessments_list)
         self.Assessments = pd.concat(

--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -345,7 +345,7 @@ class XMLtoCSV:
             assessment_elements = list(
                 set(assessment_columns).difference(set(self.id_cols))
             )
-            
+
             if assessment_factors is not None:
                 # if statement handles the non-iterable NoneType that .find produces if the element is not present.
                 for factor in assessment_factors:
@@ -364,7 +364,9 @@ class XMLtoCSV:
                     [self.AssessmentFactorsList, assessment_factors_df],
                     ignore_index=True,
                 )
-            assessment_dict["AssessmentFactors"] = assessment_factors_df["AssessmentFactor"].tolist()
+            assessment_dict["AssessmentFactors"] = assessment_factors_df[
+                "AssessmentFactor"
+            ].tolist()
             assessments_list.append(assessment_dict)
 
         assessments_df = pd.DataFrame(assessments_list)

--- a/cin_validator/ingress.py
+++ b/cin_validator/ingress.py
@@ -337,7 +337,6 @@ class XMLtoCSV:
                 "AssessmentID": self.AssessmentID,
             }
             assessment_dict = get_values(elements, assessment_dict, assessment)
-            assessments_list.append(assessment_dict)
 
             # the get_values function will not find AssessmentFactors on that level so we retrieve these separately.
             assessment_factors = assessment.find("FactorsIdentifiedAtAssessment")
@@ -346,6 +345,7 @@ class XMLtoCSV:
             assessment_elements = list(
                 set(assessment_columns).difference(set(self.id_cols))
             )
+            
             if assessment_factors is not None:
                 # if statement handles the non-iterable NoneType that .find produces if the element is not present.
                 for factor in assessment_factors:
@@ -364,6 +364,8 @@ class XMLtoCSV:
                     [self.AssessmentFactorsList, assessment_factors_df],
                     ignore_index=True,
                 )
+            assessment_dict["AssessmentFactors"] = assessment_factors_df["AssessmentFactor"].tolist()
+            assessments_list.append(assessment_dict)
 
         assessments_df = pd.DataFrame(assessments_list)
         self.Assessments = pd.concat(

--- a/cin_validator/rule_engine/__api.py
+++ b/cin_validator/rule_engine/__api.py
@@ -67,10 +67,20 @@ class CINTable(Enum):
         [
             "LAchildID",
             "CINdetailsID",
+            "AssessmentID",
             "AssessmentActualStartDate",
             "AssessmentInternalReviewDate",
             "AssessmentAuthorisationDate",
             "AssessmentFactors",
+        ],
+    )
+    AssessmentFactorsList = Enum(
+        "AssessmentFactorsList",
+        [
+            "LAchildID",
+            "CINdetailsID",
+            "AssessmentID",
+            "AssessmentFactor",
         ],
     )
     CINplanDates = Enum(


### PR DESCRIPTION
### Current

Ingress creates a separate row in the Assessments dataframe for each AssessmentFactors value within a LAchildID-CINdetailsID-AssessmentActualStartDate set.  This means that where an assessment has many factors assigned, the assessment is duplicated within the dataset and any in-error assessments are reported multiple times in the FE.

### Proposed

Amend ingress to store the assessment factors in a separate dataframe, linked to the parent assessment (and CINdetailsID) via a new internally incremented AssessmentID value.    I have ensured that the AssessmentFactors column remains on the Assessments dataframe, but now as a single string containing a list of the factors assigned on the assessment.

The new AssessmentFactorsList dataframe can be used within the relevant validations rules to return the incorrect records, while at the same time being ignored for other validation rules that do not involve assessment factors.  This will remove unnecessary duplicate assessment rows from both the validation rules and the FE error lists.

**Note:** I am not 100% sure how the FE data tables are built and whether some corresponding changes need to be made on that side to handle this change (e.g. do they use the dataframes from ingress or a separate parsing from the uploaded source files).