### PR TITLE
remove token. enable trusted publishing only

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,9 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-    environment: pypi-release
+    permissions:
++     # IMPORTANT: this permission is mandatory for trusted publishing
++     id-token: write
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +26,5 @@ jobs:
     - name: Build package
       run: poetry build
       
-    - name: Publish package
-      run: poetry publish
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1 


### PR DESCRIPTION
- Removes static API tokens. Publishing to PyPI will now only go through the [recommended](https://docs.pypi.org/trusted-publishers/using-a-publisher/) path using github as a trusted publisher.