### PR TITLE
fix syntax.publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,8 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-+     # IMPORTANT: this permission is mandatory for trusted publishing
-+     id-token: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes syntax error in python-publish.yml which could have popped up at deploy time.
Related to https://github.com/data-to-insight/csc-validator-be-cin/pull/481