### PR TITLE
pin poetry version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Install Poetry 📜
       uses: snok/install-poetry@v1
+      with:
+        version: 1.8.5
 
     - name: Build package
       run: poetry build


### PR DESCRIPTION
pin poetry version to ensure python compatibility
similar to what was done on the 903 repo https://github.com/data-to-insight/csc-validator-be-903/pull/802

Poetry version 2.0 and above, which was released recently, is incompatible with python 3.8 which these tools are dependent upon. The changes in this pull request change the default from pulling the latest poetry version. Instead a specific poetry version is specified which we're sure is compatible with our chosen python version.